### PR TITLE
Update `prepare_temp_folder` outside of HTTP request context

### DIFF
--- a/janeway_ftp/helpers.py
+++ b/janeway_ftp/helpers.py
@@ -11,32 +11,37 @@ from django.http import HttpRequest
 from core import files
 
 
-def prepare_temp_folder(request=None, issue=None, article=None, loc_code=None):
+def prepare_temp_folder(request=None, issue=None, article=None, loc_code=None, journal_code=None):
     """
-    Perpares a temp folder to store files for zipping
+    Prepares a temp folder to store files for zipping
     :param request: Request object
     :param issue: Issue Object
     :param article: Article object
     :param loc_code: string
+    :param journal_code: string
     :return: Folder path, string
     """
     folder_string = str(uuid.uuid4())
+    request_journal_code = getattr(getattr(request, "journal", None), "code", None)
 
-    if article and issue and request:
+    if journal_code is None and request_journal_code:
+        journal_code = request_journal_code
+
+    if article and issue and journal_code:
         folder_string = '{journal_code}_{vol}_{issue}_{pk}'.format(
-            journal_code=request.journal.code,
+            journal_code=journal_code,
             vol=issue.volume,
             issue=issue.issue,
             pk=article.pk)
-    elif issue and request:
+    elif issue and journal_code:
         folder_string = '{journal_code}_{vol}_{issue}_{year}'.format(
-            journal_code=request.journal.code,
+            journal_code=journal_code,
             vol=issue.volume,
             issue=issue.issue,
             year=issue.date.year)
-    elif article and request:
+    elif article and journal_code:
         folder_string = '{journal_code}_{article_id}'.format(
-            journal_code=request.journal.code,
+            journal_code=journal_code,
             article_id=article.pk)
     elif loc_code:
         folder_string = loc_code


### PR DESCRIPTION
This PR stems from adding background tasks (via django-tasks) to Production Transporter.

As part of this update, all arguments passed to a task must be serialized. Because of this, I've had to deconstruct Django’s WSGIRequest (subclass of HTTPRequest) into a dictionary, which can then be passed to the task for serialization. As a result of this change, the `prepare_temp_folder` in janeway-ftp fails to access `request.journal.code` because the background task's request has now been converted to a dictionary and serialized.

This PR updates janeway-ftp to accept a `journal_code` parameter directly rather than having to use the nested information from the `request`.

To test this, submit a manuscript using SFTP. The operation should be submitted as usual.